### PR TITLE
Fixed Execute() async method call

### DIFF
--- a/WpfAsyncPack/Command/AsyncCommand{T}.cs
+++ b/WpfAsyncPack/Command/AsyncCommand{T}.cs
@@ -31,8 +31,8 @@ namespace WpfAsyncPack.Command
         /// </summary>
         public event EventHandler CanExecuteChanged
         {
-            add => CommandManager.RequerySuggested += value;
-            remove => CommandManager.RequerySuggested -= value;
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
         }
 
         /// <summary>

--- a/WpfAsyncPack/Command/AsyncCommand{T}.cs
+++ b/WpfAsyncPack/Command/AsyncCommand{T}.cs
@@ -101,6 +101,15 @@ namespace WpfAsyncPack.Command
         }
 
         /// <summary>
+        /// Executes the command. Internally the execute will be executed asynchronously.
+        /// </summary>
+        /// <param name="parameter">Data used by the command.</param>
+        public async void Execute(object parameter = null)
+        {
+            await ExecuteAsync((T)parameter );
+        }
+
+        /// <summary>
         /// Asynchronously executes the command.
         /// </summary>
         /// <param name="parameter">Data used by the command.</param>
@@ -133,11 +142,6 @@ namespace WpfAsyncPack.Command
         bool ICommand.CanExecute(object parameter)
         {
             return CanExecute((T)parameter);
-        }
-
-        void ICommand.Execute(object parameter)
-        {
-            Execute((T)parameter);
         }
     }
 }

--- a/WpfAsyncPack/Command/SyncCommand{T}.cs
+++ b/WpfAsyncPack/Command/SyncCommand{T}.cs
@@ -24,8 +24,8 @@ namespace WpfAsyncPack.Command
         /// </summary>
         public event EventHandler CanExecuteChanged
         {
-            add => CommandManager.RequerySuggested += value;
-            remove => CommandManager.RequerySuggested -= value;
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
         }
 
         /// <summary>

--- a/WpfAsyncPack/Internal/CancelAsyncCommand.cs
+++ b/WpfAsyncPack/Internal/CancelAsyncCommand.cs
@@ -11,8 +11,8 @@ namespace WpfAsyncPack.Internal
 
         public event EventHandler CanExecuteChanged
         {
-            add => CommandManager.RequerySuggested += value;
-            remove => CommandManager.RequerySuggested -= value;
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
         }
 
         public CancellationToken Token => _cancellationTokenSource.Token;


### PR DESCRIPTION
On first commit of generic IAsyncCommand, there was mistake on implementing method from `ICommand.Execute(object parameter)` which will not be awaited properly. This PR fix that.